### PR TITLE
feat: Auth-User 내부 통신용 APIs

### DIFF
--- a/src/main/java/com/dayaeyak/user/common/entity/ApiResponse.java
+++ b/src/main/java/com/dayaeyak/user/common/entity/ApiResponse.java
@@ -1,0 +1,21 @@
+package com.dayaeyak.user.common.entity;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public record ApiResponse<T>(
+        String message,
+
+        T data
+) {
+
+    public static <T> ResponseEntity<ApiResponse<T>> success(HttpStatus status, String message, T data) {
+        return ResponseEntity.status(status.value())
+                .body(new ApiResponse<>(message, data));
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> error(HttpStatus status, String message) {
+        return ResponseEntity.status(status.value())
+                .body(new ApiResponse<>(message, null));
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/entity/BaseEntity.java
+++ b/src/main/java/com/dayaeyak/user/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.dayaeyak.user.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", updatable = false, nullable = false)
+    protected LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    public void delete(){
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/CustomInternalException.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/CustomInternalException.java
@@ -1,0 +1,19 @@
+package com.dayaeyak.user.common.exception;
+
+import com.dayaeyak.user.common.exception.type.ExceptionType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomInternalException extends RuntimeException {
+
+    private final HttpStatus status;
+    private final String message;
+
+    public CustomInternalException(ExceptionType e) {
+        super(e.getMessage());
+
+        this.status = e.getStatus();
+        this.message = e.getMessage();
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/CustomRuntimeException.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/CustomRuntimeException.java
@@ -1,0 +1,19 @@
+package com.dayaeyak.user.common.exception;
+
+import com.dayaeyak.user.common.exception.type.ExceptionType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomRuntimeException extends RuntimeException {
+
+    private final HttpStatus status;
+    private final String message;
+
+    public CustomRuntimeException(ExceptionType e) {
+        super(e.getMessage());
+
+        this.status = e.getStatus();
+        this.message = e.getMessage();
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/ExceptionResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/ExceptionResponseDto.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.user.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public record ExceptionResponseDto(
+        HttpStatus status,
+
+        String message
+) {
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.dayaeyak.user.common.exception;
+
+import com.dayaeyak.user.common.entity.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomRuntimeException.class)
+    public ResponseEntity<ApiResponse<ExceptionResponseDto>> handleCustomException(CustomRuntimeException e) {
+        return ApiResponse.error(e.getStatus(), e.getMessage());
+    }
+
+    @ExceptionHandler(CustomInternalException.class)
+    public ResponseEntity<String> handleCustomInternalException(CustomInternalException e) {
+        return ResponseEntity.status(e.getStatus())
+                .body(e.getMessage());
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/type/ExceptionType.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/type/ExceptionType.java
@@ -1,0 +1,9 @@
+package com.dayaeyak.user.common.exception.type;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionType {
+
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/type/UserExceptionType.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/type/UserExceptionType.java
@@ -1,0 +1,19 @@
+package com.dayaeyak.user.common.exception.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserExceptionType implements ExceptionType {
+
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT,"이미 존재하는 닉네임입니다."),
+    INVALID_USER_ROLE(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저 권한입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/User.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/User.java
@@ -1,0 +1,50 @@
+package com.dayaeyak.user.domain.user;
+
+import com.dayaeyak.user.common.entity.BaseEntity;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false, unique = true, length = 10)
+    private String nickname;
+
+    @Column(nullable = false, length = 15)
+    private String phone;
+
+    @Column(nullable = false, columnDefinition = "TINYINT")
+    private Integer age;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    UserRole role;
+
+    @Builder
+    public User(String email, String password, String nickname, String phone, Integer age, UserRole role) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.phone = phone;
+        this.age = age;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
@@ -1,0 +1,33 @@
+package com.dayaeyak.user.domain.user;
+
+import com.dayaeyak.user.domain.user.dto.request.UserCreateRequestDto;
+import com.dayaeyak.user.domain.user.dto.request.UserFindByEmailRequestDto;
+import com.dayaeyak.user.domain.user.dto.response.UserCreateResponseDto;
+import com.dayaeyak.user.domain.user.dto.response.UserFindByEmailResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/users")
+@RequiredArgsConstructor
+public class UserInternalController {
+
+    private final UserInternalService userInternalService;
+
+    @PostMapping("/create-user")
+    public UserCreateResponseDto createUser(
+            @RequestBody UserCreateRequestDto userCreateRequestDto
+    ) {
+        return userInternalService.createUser(userCreateRequestDto);
+    }
+
+    @PostMapping("/find-user")
+    public UserFindByEmailResponseDto findUser(
+            @RequestBody UserFindByEmailRequestDto userFindByEmailRequestDto
+    ) {
+        return userInternalService.findUserByEmail(userFindByEmailRequestDto);
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalService.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalService.java
@@ -1,0 +1,52 @@
+package com.dayaeyak.user.domain.user;
+
+import com.dayaeyak.user.common.exception.CustomInternalException;
+import com.dayaeyak.user.common.exception.type.UserExceptionType;
+import com.dayaeyak.user.domain.user.dto.request.UserCreateRequestDto;
+import com.dayaeyak.user.domain.user.dto.request.UserFindByEmailRequestDto;
+import com.dayaeyak.user.domain.user.dto.response.UserCreateResponseDto;
+import com.dayaeyak.user.domain.user.dto.response.UserFindByEmailResponseDto;
+import com.dayaeyak.user.domain.user.jpa.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserInternalService {
+
+    private final UserJpaRepository userJpaRepository;
+
+    public UserCreateResponseDto createUser(UserCreateRequestDto dto) {
+        if (userJpaRepository.existsByEmail(dto.email())) {
+            throw new CustomInternalException(UserExceptionType.DUPLICATED_EMAIL);
+        }
+
+        if (userJpaRepository.existsByNickname(dto.nickname())) {
+            throw new CustomInternalException(UserExceptionType.DUPLICATED_NICKNAME);
+        }
+
+        User user = User.builder()
+                .email(dto.email())
+                .password(dto.password())
+                .nickname(dto.nickname())
+                .phone(dto.phone())
+                .age(dto.age())
+                .role(dto.role())
+                .build();
+
+        userJpaRepository.save(user);
+
+        return UserCreateResponseDto.from(user);
+    }
+
+    public UserFindByEmailResponseDto findUserByEmail(UserFindByEmailRequestDto dto) {
+        User user = findUserByEmail(dto.email());
+
+        return UserFindByEmailResponseDto.from(user);
+    }
+
+    private User findUserByEmail(String email) {
+        return userJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomInternalException(UserExceptionType.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserCreateRequestDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserCreateRequestDto.java
@@ -1,0 +1,18 @@
+package com.dayaeyak.user.domain.user.dto.request;
+
+import com.dayaeyak.user.domain.user.enums.UserRole;
+
+public record UserCreateRequestDto(
+        String email,
+
+        String password,
+
+        String nickname,
+
+        Integer age,
+
+        String phone,
+
+        UserRole role
+) {
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserFindByEmailRequestDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserFindByEmailRequestDto.java
@@ -1,0 +1,6 @@
+package com.dayaeyak.user.domain.user.dto.request;
+
+public record UserFindByEmailRequestDto(
+        String email
+) {
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserCreateResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserCreateResponseDto.java
@@ -1,0 +1,15 @@
+package com.dayaeyak.user.domain.user.dto.response;
+
+import com.dayaeyak.user.domain.user.User;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+
+public record UserCreateResponseDto(
+        Long userId,
+
+        UserRole role
+) {
+
+    public static UserCreateResponseDto from(User user) {
+        return new UserCreateResponseDto(user.getId(), user.getRole());
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserFindByEmailResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserFindByEmailResponseDto.java
@@ -1,0 +1,17 @@
+package com.dayaeyak.user.domain.user.dto.response;
+
+import com.dayaeyak.user.domain.user.User;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+
+public record UserFindByEmailResponseDto(
+        Long userId,
+
+        String password,
+
+        UserRole role
+) {
+
+    public static UserFindByEmailResponseDto from(User user) {
+        return new UserFindByEmailResponseDto(user.getId(), user.getPassword(), user.getRole());
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/UserRole.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/UserRole.java
@@ -1,0 +1,25 @@
+package com.dayaeyak.user.domain.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    MASTER("MASTER"),
+    SELLER("SELLER"),
+    NORMAL("NORMAL"),
+    ;
+
+    private final String role;
+
+    public static UserRole of(String role) {
+        return Stream.of(UserRole.values())
+                .filter(userRole -> userRole.role.equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/jpa/UserJpaRepository.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/jpa/UserJpaRepository.java
@@ -1,0 +1,14 @@
+package com.dayaeyak.user.domain.user.jpa;
+
+import com.dayaeyak.user.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<User> findByEmail(String email);
+}


### PR DESCRIPTION
## 📝 요약(Summary)

내부 통신 용 API
1. 회원가입 API
2. 이메일로 유저 조회 API

## 💫 구현 및 변경 사항 (Details)

내부 API에서는 굳이 restful하게 설계하지 않고 일단은 예외 발생시 상태 값 변경과 메세지만 보내도록 했습니다.

## 📸스크린샷 (선택)

<!--- API 테스트 결과 스크린샷 -->

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [x] Reviewers에 팀원 등록


## 💬 TODO ( 미완성일 경우 )

## 기타/주의사항
