### PR TITLE
feat: 소셜 로그인 로직 구현

### DIFF
--- a/src/main/java/com/dayaeyak/user/common/annotation/PassportHolder.java
+++ b/src/main/java/com/dayaeyak/user/common/annotation/PassportHolder.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
 public @interface PassportHolder {
 }

--- a/src/main/java/com/dayaeyak/user/common/annotation/PassportHolder.java
+++ b/src/main/java/com/dayaeyak/user/common/annotation/PassportHolder.java
@@ -1,0 +1,11 @@
+package com.dayaeyak.user.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PassportHolder {
+}

--- a/src/main/java/com/dayaeyak/user/common/config/WebConfig.java
+++ b/src/main/java/com/dayaeyak/user/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.dayaeyak.user.common.config;
+
+import com.dayaeyak.user.common.resolver.PassportHolderArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final PassportHolderArgumentResolver passportHolderArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(passportHolderArgumentResolver);
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/constant/UserResponseMessage.java
+++ b/src/main/java/com/dayaeyak/user/common/constant/UserResponseMessage.java
@@ -1,4 +1,4 @@
-package com.dayaeyak.user.common.constraints;
+package com.dayaeyak.user.common.constant;
 
 public class UserResponseMessage {
 

--- a/src/main/java/com/dayaeyak/user/common/constant/UserValidationMessage.java
+++ b/src/main/java/com/dayaeyak/user/common/constant/UserValidationMessage.java
@@ -1,4 +1,4 @@
-package com.dayaeyak.user.common.constraints;
+package com.dayaeyak.user.common.constant;
 
 public class UserValidationMessage {
 

--- a/src/main/java/com/dayaeyak/user/common/constraints/UserResponseMessage.java
+++ b/src/main/java/com/dayaeyak/user/common/constraints/UserResponseMessage.java
@@ -2,6 +2,10 @@ package com.dayaeyak.user.common.constraints;
 
 public class UserResponseMessage {
 
-    public static final String GET_MY_PAGE_SUCCESS = "마이페이지 조회에 성공하였습니다.";
-    public static final String UPDATE_MY_PAGE_SUCCESS = "마이페이지 수정에 성공하였습니다.";
+    public static final String GET_MY_PAGE = "마이페이지 조회에 성공하였습니다.";
+    public static final String UPDATE_MY_PAGE = "마이페이지 수정에 성공하였습니다.";
+
+    // admin controller
+    public static final String SEARCH = "유저 검색에 성공하였습니다.";
+    public static final String UPDATE = "유저 수정에 성공하였습니다.";
 }

--- a/src/main/java/com/dayaeyak/user/common/converter/SearchTypeConverter.java
+++ b/src/main/java/com/dayaeyak/user/common/converter/SearchTypeConverter.java
@@ -1,0 +1,14 @@
+package com.dayaeyak.user.common.converter;
+
+import com.dayaeyak.user.domain.user.enums.SearchType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SearchTypeConverter implements Converter<String, SearchType> {
+
+    @Override
+    public SearchType convert(String source) {
+        return SearchType.of(source);
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/dto/PageInfoResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/common/dto/PageInfoResponseDto.java
@@ -1,0 +1,28 @@
+package com.dayaeyak.user.common.dto;
+
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+public record PageInfoResponseDto(
+        int pageNumber,
+
+        int pageSize,
+
+        long totalElements,
+
+        int totalPages,
+
+        boolean last
+) {
+
+    public static <T> PageInfoResponseDto from(Page<T> data) {
+        return PageInfoResponseDto.builder()
+                .pageNumber(data.getNumber())
+                .pageSize(data.getSize())
+                .totalElements(data.getTotalElements())
+                .totalPages(data.getTotalPages())
+                .last(data.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/dayaeyak/user/common/dto/Passport.java
+++ b/src/main/java/com/dayaeyak/user/common/dto/Passport.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.user.common.dto;
+
+import com.dayaeyak.user.domain.user.enums.UserRole;
+
+public record Passport(
+        Long userId,
+
+        UserRole role
+) {
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/type/CommonExceptionType.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/type/CommonExceptionType.java
@@ -1,0 +1,18 @@
+package com.dayaeyak.user.common.exception.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonExceptionType implements ExceptionType {
+
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 ID입니다."),
+    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 권한입니다."),
+    REQUEST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "요청 접근 권한이 부족합니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dayaeyak/user/common/exception/type/UserExceptionType.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/type/UserExceptionType.java
@@ -11,9 +11,10 @@ public enum UserExceptionType implements ExceptionType {
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT,"이미 존재하는 닉네임입니다."),
     DUPLICATED_PHONE(HttpStatus.CONFLICT,"이미 존재하는 휴대폰 번호입니다."),
-    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 권한입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
-    INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 검색어 타입입니다.");
+    INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 검색어 타입입니다."),
+    INVALID_PROVIDER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 계정 타입입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/dayaeyak/user/common/exception/type/UserExceptionType.java
+++ b/src/main/java/com/dayaeyak/user/common/exception/type/UserExceptionType.java
@@ -11,9 +11,9 @@ public enum UserExceptionType implements ExceptionType {
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT,"이미 존재하는 닉네임입니다."),
     DUPLICATED_PHONE(HttpStatus.CONFLICT,"이미 존재하는 휴대폰 번호입니다."),
-    INVALID_USER_ROLE(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저 권한입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다.")
-    ;
+    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 유저 권한입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
+    INVALID_SEARCH_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 검색어 타입입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/dayaeyak/user/common/resolver/PassportHolderArgumentResolver.java
+++ b/src/main/java/com/dayaeyak/user/common/resolver/PassportHolderArgumentResolver.java
@@ -2,18 +2,19 @@ package com.dayaeyak.user.common.resolver;
 
 import com.dayaeyak.user.common.annotation.PassportHolder;
 import com.dayaeyak.user.common.dto.Passport;
+import com.dayaeyak.user.common.exception.CustomRuntimeException;
+import com.dayaeyak.user.common.exception.type.CommonExceptionType;
 import com.dayaeyak.user.domain.user.enums.UserRole;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PassportHolderArgumentResolver implements HandlerMethodArgumentResolver {
@@ -33,11 +34,18 @@ public class PassportHolderArgumentResolver implements HandlerMethodArgumentReso
             ModelAndViewContainer mavContainer,
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
-    ) throws Exception {
-        log.info("PassportPrincipalArgumentResolver.resolveArgument");
+    ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String id = request.getHeader(USER_ID_HEADER);
         String role = request.getHeader(USER_ROLE_HEADER);
+
+        if (!StringUtils.hasText(id)) {
+            throw new CustomRuntimeException(CommonExceptionType.INVALID_USER_ID);
+        }
+
+        if (!StringUtils.hasText(role)) {
+            throw new CustomRuntimeException(CommonExceptionType.INVALID_USER_ROLE);
+        }
 
         return new Passport(
                 Long.valueOf(id),

--- a/src/main/java/com/dayaeyak/user/common/resolver/PassportHolderArgumentResolver.java
+++ b/src/main/java/com/dayaeyak/user/common/resolver/PassportHolderArgumentResolver.java
@@ -1,0 +1,47 @@
+package com.dayaeyak.user.common.resolver;
+
+import com.dayaeyak.user.common.annotation.PassportHolder;
+import com.dayaeyak.user.common.dto.Passport;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PassportHolderArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(PassportHolder.class)
+                && parameter.getParameterType().equals(Passport.class);
+    }
+
+    @Override
+    public Passport resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+        log.info("PassportPrincipalArgumentResolver.resolveArgument");
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String id = request.getHeader(USER_ID_HEADER);
+        String role = request.getHeader(USER_ROLE_HEADER);
+
+        return new Passport(
+                Long.valueOf(id),
+                UserRole.of(role)
+        );
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/User.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.dayaeyak.user.domain.user;
 
 import com.dayaeyak.user.common.entity.BaseEntity;
+import com.dayaeyak.user.domain.user.dto.request.UserAdminUpdateRequestDto;
 import com.dayaeyak.user.domain.user.dto.request.UserUpdateRequestDto;
 import com.dayaeyak.user.domain.user.enums.UserRole;
 import jakarta.persistence.*;
@@ -54,9 +55,20 @@ public class User extends BaseEntity {
         updateNickname(dto.nickname());
     }
 
+    public void updateByAdmin(UserAdminUpdateRequestDto dto) {
+        updateNickname(dto.nickname());
+        updateUserRole(dto.role());
+    }
+
     private void updateNickname(String nickname) {
         if (StringUtils.hasText(nickname)) {
             this.nickname = nickname;
+        }
+    }
+
+    private void updateUserRole(UserRole role) {
+        if (role != null) {
+            this.role = role;
         }
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/User.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/User.java
@@ -25,7 +25,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true, length = 50)
     private String email;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String password;
 
     @Column(nullable = false, unique = true, length = 10)

--- a/src/main/java/com/dayaeyak/user/domain/user/UserAdminController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserAdminController.java
@@ -1,6 +1,6 @@
 package com.dayaeyak.user.domain.user;
 
-import com.dayaeyak.user.common.constraints.UserResponseMessage;
+import com.dayaeyak.user.common.constant.UserResponseMessage;
 import com.dayaeyak.user.common.entity.ApiResponse;
 import com.dayaeyak.user.domain.user.dto.request.UserAdminUpdateRequestDto;
 import com.dayaeyak.user.domain.user.dto.response.UserSearchPageResponseDto;

--- a/src/main/java/com/dayaeyak/user/domain/user/UserAdminController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserAdminController.java
@@ -1,0 +1,45 @@
+package com.dayaeyak.user.domain.user;
+
+import com.dayaeyak.user.common.constraints.UserResponseMessage;
+import com.dayaeyak.user.common.entity.ApiResponse;
+import com.dayaeyak.user.domain.user.dto.request.UserAdminUpdateRequestDto;
+import com.dayaeyak.user.domain.user.dto.response.UserSearchPageResponseDto;
+import com.dayaeyak.user.domain.user.dto.response.UserUpdateResponseDto;
+import com.dayaeyak.user.domain.user.enums.SearchType;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/users")
+@RequiredArgsConstructor
+public class UserAdminController {
+
+    private final UserAdminService userAdminService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserSearchPageResponseDto>> searchUser(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) UserRole role,
+            @RequestParam String keyword,
+            @RequestParam SearchType searchType
+    ) {
+        UserSearchPageResponseDto data = userAdminService.searchUser(page, size, userId, role, keyword, searchType);
+
+        return ApiResponse.success(HttpStatus.OK, UserResponseMessage.SEARCH, data);
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<ApiResponse<UserUpdateResponseDto>> updateUser(
+            @PathVariable Long userId,
+            @RequestBody UserAdminUpdateRequestDto userAdminUpdateRequestDto
+    ) {
+        UserUpdateResponseDto data = userAdminService.updateUser(userId, userAdminUpdateRequestDto);
+
+        return ApiResponse.success(HttpStatus.OK, UserResponseMessage.UPDATE, data);
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/UserAdminService.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserAdminService.java
@@ -1,0 +1,55 @@
+package com.dayaeyak.user.domain.user;
+
+import com.dayaeyak.user.common.exception.CustomInternalException;
+import com.dayaeyak.user.common.exception.type.UserExceptionType;
+import com.dayaeyak.user.domain.user.dto.request.UserAdminUpdateRequestDto;
+import com.dayaeyak.user.domain.user.dto.response.UserSearchPageResponseDto;
+import com.dayaeyak.user.domain.user.dto.response.UserUpdateResponseDto;
+import com.dayaeyak.user.domain.user.enums.SearchType;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+import com.dayaeyak.user.domain.user.jpa.UserJpaRepository;
+import com.dayaeyak.user.domain.user.querydsl.UserQuerydslRepository;
+import com.dayaeyak.user.domain.user.querydsl.dto.response.UserSearchProjectionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAdminService {
+
+    private final UserJpaRepository userJpaRepository;
+    private final UserQuerydslRepository userQuerydslRepository;
+
+    public UserSearchPageResponseDto searchUser(
+            int page,
+            int size,
+            Long userId,
+            UserRole role,
+            String keyword,
+            SearchType searchType
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<UserSearchProjectionDto> data
+                = userQuerydslRepository.searchPage(pageable, userId, role, keyword, searchType);
+
+        return UserSearchPageResponseDto.from(data);
+    }
+
+    @Transactional
+    public UserUpdateResponseDto updateUser(Long userId, UserAdminUpdateRequestDto dto) {
+        User user = findById(userId);
+        user.updateByAdmin(dto);
+
+        return UserUpdateResponseDto.from(user);
+    }
+
+    private User findById(Long userId) {
+        return userJpaRepository.findById(userId)
+                .orElseThrow(() -> new CustomInternalException(UserExceptionType.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/UserController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserController.java
@@ -1,7 +1,7 @@
 package com.dayaeyak.user.domain.user;
 
 import com.dayaeyak.user.common.annotation.PassportHolder;
-import com.dayaeyak.user.common.constraints.UserResponseMessage;
+import com.dayaeyak.user.common.constant.UserResponseMessage;
 import com.dayaeyak.user.common.dto.Passport;
 import com.dayaeyak.user.common.entity.ApiResponse;
 import com.dayaeyak.user.domain.user.dto.request.UserUpdateRequestDto;

--- a/src/main/java/com/dayaeyak/user/domain/user/UserController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserController.java
@@ -1,6 +1,8 @@
 package com.dayaeyak.user.domain.user;
 
+import com.dayaeyak.user.common.annotation.PassportHolder;
 import com.dayaeyak.user.common.constraints.UserResponseMessage;
+import com.dayaeyak.user.common.dto.Passport;
 import com.dayaeyak.user.common.entity.ApiResponse;
 import com.dayaeyak.user.domain.user.dto.request.UserUpdateRequestDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindMyPageResponseDto;
@@ -20,20 +22,20 @@ public class UserController {
 
     @GetMapping("/my")
     public ResponseEntity<ApiResponse<UserFindMyPageResponseDto>> getMyPage(
-            @RequestHeader("X-User-Id") Long userId
+            @PassportHolder Passport passport
     ) {
-        UserFindMyPageResponseDto data = userService.findMyPage(userId);
+        UserFindMyPageResponseDto data = userService.findMyPage(passport);
 
-        return ApiResponse.success(HttpStatus.OK, UserResponseMessage.GET_MY_PAGE_SUCCESS, data);
+        return ApiResponse.success(HttpStatus.OK, UserResponseMessage.GET_MY_PAGE, data);
     }
 
     @PatchMapping("/my")
     public ResponseEntity<ApiResponse<UserUpdateResponseDto>> updateMyPage(
             @RequestBody @Valid UserUpdateRequestDto userUpdateRequestDto,
-            @RequestHeader("X-User-Id") Long userId
+            @PassportHolder Passport passport
     ) {
-        UserUpdateResponseDto data = userService.updateMyPage(userUpdateRequestDto, userId);
+        UserUpdateResponseDto data = userService.updateMyPage(userUpdateRequestDto, passport);
 
-        return ApiResponse.success(HttpStatus.OK, UserResponseMessage.UPDATE_MY_PAGE_SUCCESS, data);
+        return ApiResponse.success(HttpStatus.OK, UserResponseMessage.UPDATE_MY_PAGE, data);
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
@@ -5,11 +5,7 @@ import com.dayaeyak.user.domain.user.dto.request.UserFindByEmailRequestDto;
 import com.dayaeyak.user.domain.user.dto.response.UserCreateResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByEmailResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByIdResponseDto;
-import com.dayaeyak.user.domain.user.dto.response.UserSearchPageResponseDto;
-import com.dayaeyak.user.domain.user.enums.UserRole;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -38,17 +34,5 @@ public class UserInternalController {
             @PathVariable Long userId
     ) {
         return userInternalService.findUserById(userId);
-    }
-
-    @GetMapping
-    public UserSearchPageResponseDto searchUser(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) Long userId,
-            @RequestParam(required = false) String email,
-            @RequestParam(required = false) String nickname,
-            @RequestParam(required = false) UserRole role
-    ) {
-        return userInternalService.searchUser(page, size, userId, email, nickname, role);
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
@@ -23,7 +23,7 @@ public class UserInternalController {
     }
 
     @PostMapping("/find-user")
-    public UserFindByEmailResponseDto findUser(
+    public UserFindByEmailResponseDto getUser(
             @RequestBody UserFindByEmailRequestDto userFindByEmailRequestDto
     ) {
         return userInternalService.findUserByEmail(userFindByEmailRequestDto);

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalController.java
@@ -2,9 +2,11 @@ package com.dayaeyak.user.domain.user;
 
 import com.dayaeyak.user.domain.user.dto.request.UserCreateRequestDto;
 import com.dayaeyak.user.domain.user.dto.request.UserFindByEmailRequestDto;
+import com.dayaeyak.user.domain.user.dto.request.UserSocialLoginRequestDto;
 import com.dayaeyak.user.domain.user.dto.response.UserCreateResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByEmailResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByIdResponseDto;
+import com.dayaeyak.user.domain.user.dto.response.UserSocialLoginResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,5 +36,12 @@ public class UserInternalController {
             @PathVariable Long userId
     ) {
         return userInternalService.findUserById(userId);
+    }
+
+    @PostMapping("/social-login")
+    public UserSocialLoginResponseDto socialLogin(
+        @RequestBody UserSocialLoginRequestDto userSocialLoginRequestDto
+    ) {
+        return userInternalService.socialLogin(userSocialLoginRequestDto);
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalService.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalService.java
@@ -4,18 +4,24 @@ import com.dayaeyak.user.common.exception.CustomInternalException;
 import com.dayaeyak.user.common.exception.type.UserExceptionType;
 import com.dayaeyak.user.domain.user.dto.request.UserCreateRequestDto;
 import com.dayaeyak.user.domain.user.dto.request.UserFindByEmailRequestDto;
+import com.dayaeyak.user.domain.user.dto.request.UserSocialLoginRequestDto;
 import com.dayaeyak.user.domain.user.dto.response.UserCreateResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByEmailResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByIdResponseDto;
+import com.dayaeyak.user.domain.user.dto.response.UserSocialLoginResponseDto;
 import com.dayaeyak.user.domain.user.jpa.UserJpaRepository;
+import com.dayaeyak.user.domain.user.jpa.UserSocialJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class UserInternalService {
 
     private final UserJpaRepository userJpaRepository;
+    private final UserSocialJpaRepository userSocialJpaRepository;
 
     public UserCreateResponseDto createUser(UserCreateRequestDto dto) {
         if (userJpaRepository.existsByEmail(dto.email())) {
@@ -54,6 +60,33 @@ public class UserInternalService {
         User user = findById(userId);
 
         return UserFindByIdResponseDto.from(user);
+    }
+
+    public UserSocialLoginResponseDto socialLogin(UserSocialLoginRequestDto dto) {
+        // 소셜 서비스에 저장된 email로 유저 테이블 조회
+        Optional<User> optionalUser = userJpaRepository.findByEmail(dto.email());
+
+        // case 계정 존재 X
+        // 소셜 회원 가입(추가 정보)
+        if (optionalUser.isEmpty()) {
+            return UserSocialLoginResponseDto.joinRequired();
+        }
+
+        // case 계정 존재 O
+        User user = optionalUser.get();
+
+        // 만약 소셜 정보가 없다면 새로 등록
+        if (!userSocialJpaRepository.existsByUserAndProviderTypeAndProviderId(user, dto.providerType(), dto.providerId())) {
+            connectSocialWithUser(user, dto);
+        }
+
+        // 로그인 완료
+        return UserSocialLoginResponseDto.success(user.getId(), user.getRole());
+    }
+
+    private void connectSocialWithUser(User user, UserSocialLoginRequestDto dto) {
+        UserSocial userSocial = new UserSocial(user, dto.providerType(), dto.providerId());
+        userSocialJpaRepository.save(userSocial);
     }
 
     private User findUserByEmail(String email) {

--- a/src/main/java/com/dayaeyak/user/domain/user/UserInternalService.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserInternalService.java
@@ -7,15 +7,8 @@ import com.dayaeyak.user.domain.user.dto.request.UserFindByEmailRequestDto;
 import com.dayaeyak.user.domain.user.dto.response.UserCreateResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByEmailResponseDto;
 import com.dayaeyak.user.domain.user.dto.response.UserFindByIdResponseDto;
-import com.dayaeyak.user.domain.user.dto.response.UserSearchPageResponseDto;
-import com.dayaeyak.user.domain.user.enums.UserRole;
 import com.dayaeyak.user.domain.user.jpa.UserJpaRepository;
-import com.dayaeyak.user.domain.user.querydsl.UserQuerydslRepository;
-import com.dayaeyak.user.domain.user.querydsl.dto.response.UserSearchProjectionDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,7 +16,6 @@ import org.springframework.stereotype.Service;
 public class UserInternalService {
 
     private final UserJpaRepository userJpaRepository;
-    private final UserQuerydslRepository userQuerydslRepository;
 
     public UserCreateResponseDto createUser(UserCreateRequestDto dto) {
         if (userJpaRepository.existsByEmail(dto.email())) {
@@ -62,22 +54,6 @@ public class UserInternalService {
         User user = findById(userId);
 
         return UserFindByIdResponseDto.from(user);
-    }
-
-    public UserSearchPageResponseDto searchUser(
-            int page,
-            int size,
-            Long userId,
-            String email,
-            String nickname,
-            UserRole role
-    ) {
-        Pageable pageable = PageRequest.of(page, size);
-
-        Page<UserSearchProjectionDto> data
-                = userQuerydslRepository.searchPage(pageable, userId, email, nickname, role);
-
-        return UserSearchPageResponseDto.from(data);
     }
 
     private User findUserByEmail(String email) {

--- a/src/main/java/com/dayaeyak/user/domain/user/UserService.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package com.dayaeyak.user.domain.user;
 
+import com.dayaeyak.user.common.dto.Passport;
 import com.dayaeyak.user.common.exception.CustomRuntimeException;
 import com.dayaeyak.user.common.exception.type.UserExceptionType;
 import com.dayaeyak.user.domain.user.dto.request.UserUpdateRequestDto;
@@ -16,15 +17,15 @@ public class UserService {
 
     private final UserJpaRepository userJpaRepository;
 
-    public UserFindMyPageResponseDto findMyPage(Long userId) {
-        User user = findUserById(userId);
+    public UserFindMyPageResponseDto findMyPage(Passport passport) {
+        User user = findUserById(passport.userId());
 
         return UserFindMyPageResponseDto.from(user);
     }
 
     @Transactional
-    public UserUpdateResponseDto updateMyPage(UserUpdateRequestDto dto, Long userId) {
-        User user = findUserById(userId);
+    public UserUpdateResponseDto updateMyPage(UserUpdateRequestDto dto, Passport passport) {
+        User user = findUserById(passport.userId());
         user.update(dto);
 
         return UserUpdateResponseDto.from(user);

--- a/src/main/java/com/dayaeyak/user/domain/user/UserSocial.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/UserSocial.java
@@ -1,0 +1,37 @@
+package com.dayaeyak.user.domain.user;
+
+import com.dayaeyak.user.common.entity.BaseEntity;
+import com.dayaeyak.user.domain.user.enums.ProviderType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_socials")
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSocial extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_social_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProviderType providerType;
+
+    @Column(nullable = false)
+    private String providerId;
+
+    public UserSocial(User user, ProviderType providerType, String providerId) {
+        this.user = user;
+        this.providerType = providerType;
+        this.providerId = providerId;
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserAdminUpdateRequestDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserAdminUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.user.domain.user.dto.request;
+
+import com.dayaeyak.user.domain.user.enums.UserRole;
+
+public record UserAdminUpdateRequestDto(
+        String nickname,
+
+        UserRole role
+) {
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserSocialLoginRequestDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserSocialLoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.dayaeyak.user.domain.user.dto.request;
+
+import com.dayaeyak.user.domain.user.enums.ProviderType;
+
+public record UserSocialLoginRequestDto(
+        ProviderType providerType,
+
+        String providerId,
+
+        String email
+) {
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/request/UserUpdateRequestDto.java
@@ -1,6 +1,6 @@
 package com.dayaeyak.user.domain.user.dto.request;
 
-import com.dayaeyak.user.common.constraints.UserValidationMessage;
+import com.dayaeyak.user.common.constant.UserValidationMessage;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserUpdateRequestDto(

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserFindMyPageResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserFindMyPageResponseDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Builder
 public record UserFindMyPageResponseDto(
@@ -21,11 +22,11 @@ public record UserFindMyPageResponseDto(
 
         UserRole role,
 
-        @JsonFormat(pattern = "yy년 MM월 dd일")
-        LocalDate createdAt,
+        @JsonFormat(pattern = "yy년 MM월 dd일 HH:mm")
+        LocalDateTime createdAt,
 
-        @JsonFormat(pattern = "yy년 MM월 dd일")
-        LocalDate updatedAt
+        @JsonFormat(pattern = "yy년 MM월 dd일 HH:mm")
+        LocalDateTime updatedAt
 ) {
 
     public static UserFindMyPageResponseDto from(User user) {
@@ -36,8 +37,8 @@ public record UserFindMyPageResponseDto(
                 .age(user.getAge())
                 .phone(user.getPhone())
                 .role(user.getRole())
-                .createdAt(user.getCreatedAt().toLocalDate())
-                .updatedAt(user.getUpdatedAt().toLocalDate())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserSearchPageResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserSearchPageResponseDto.java
@@ -1,5 +1,6 @@
 package com.dayaeyak.user.domain.user.dto.response;
 
+import com.dayaeyak.user.common.dto.PageInfoResponseDto;
 import com.dayaeyak.user.domain.user.querydsl.dto.response.UserSearchProjectionDto;
 import lombok.Builder;
 import org.springframework.data.domain.Page;
@@ -8,33 +9,20 @@ import java.util.List;
 
 @Builder
 public record UserSearchPageResponseDto(
-        int pageNumber,
-
-        int pageSize,
-
-        long totalElements,
-
-        int totalPages,
-
-        boolean first,
-
-        boolean last,
+        PageInfoResponseDto pageInfo,
 
         List<UserSearchResponseDto> data
 ) {
 
     public static UserSearchPageResponseDto from(Page<UserSearchProjectionDto> page) {
+        PageInfoResponseDto pageInfo = PageInfoResponseDto.from(page);
+
         List<UserSearchResponseDto> data = page.getContent().stream()
                 .map(UserSearchResponseDto::from)
                 .toList();
 
         return UserSearchPageResponseDto.builder()
-                .pageNumber(page.getNumber())
-                .pageSize(page.getSize())
-                .totalElements(page.getTotalElements())
-                .totalPages(page.getTotalPages())
-                .first(page.isFirst())
-                .last(page.isLast())
+                .pageInfo(pageInfo)
                 .data(data)
                 .build();
     }

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserSocialLoginResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserSocialLoginResponseDto.java
@@ -1,0 +1,22 @@
+package com.dayaeyak.user.domain.user.dto.response;
+
+
+import com.dayaeyak.user.domain.user.enums.SocialLoginFlag;
+import com.dayaeyak.user.domain.user.enums.UserRole;
+
+public record UserSocialLoginResponseDto(
+        SocialLoginFlag flag,
+
+        Long userId,
+
+        UserRole role
+) {
+
+    public static UserSocialLoginResponseDto success(Long id, UserRole role) {
+        return new UserSocialLoginResponseDto(SocialLoginFlag.SUCCESS, id, role);
+    }
+
+    public static UserSocialLoginResponseDto joinRequired() {
+        return new UserSocialLoginResponseDto(SocialLoginFlag.JOIN_REQUIRED, null, null);
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserUpdateResponseDto.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/dto/response/UserUpdateResponseDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Builder
 public record UserUpdateResponseDto(
@@ -22,10 +23,10 @@ public record UserUpdateResponseDto(
         UserRole role,
 
         @JsonFormat(pattern = "yy년 MM월 dd일 HH:mm")
-        LocalDate createdAt,
+        LocalDateTime createdAt,
 
         @JsonFormat(pattern = "yy년 MM월 dd일 HH:mm")
-        LocalDate updatedAt
+        LocalDateTime updatedAt
 ) {
 
     public static UserUpdateResponseDto from(User user) {
@@ -36,8 +37,8 @@ public record UserUpdateResponseDto(
                 .age(user.getAge())
                 .phone(user.getPhone())
                 .role(user.getRole())
-                .createdAt(user.getCreatedAt().toLocalDate())
-                .updatedAt(user.getUpdatedAt().toLocalDate())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/ProviderType.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/ProviderType.java
@@ -19,6 +19,6 @@ public enum ProviderType {
         return Arrays.stream(ProviderType.values())
                 .filter(providerType -> providerType.name().equalsIgnoreCase(value))
                 .findFirst()
-                .orElseThrow(() -> new CustomInternalException(UserExceptionType.INVALID_ACCOUNT_TYPE));
+                .orElseThrow(() -> new CustomInternalException(UserExceptionType.INVALID_PROVIDER_TYPE));
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/ProviderType.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/ProviderType.java
@@ -1,0 +1,24 @@
+package com.dayaeyak.user.domain.user.enums;
+
+import com.dayaeyak.user.common.exception.CustomInternalException;
+import com.dayaeyak.user.common.exception.type.UserExceptionType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum ProviderType {
+
+    GOOGLE,
+    KAKAO,
+    ;
+
+    @JsonCreator
+    public static ProviderType of(String value) {
+        return Arrays.stream(ProviderType.values())
+                .filter(providerType -> providerType.name().equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new CustomInternalException(UserExceptionType.INVALID_ACCOUNT_TYPE));
+    }
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
@@ -1,12 +1,12 @@
 package com.dayaeyak.user.domain.user.enums;
 
 import com.dayaeyak.user.common.exception.CustomRuntimeException;
-import com.dayaeyak.user.common.exception.type.CommonExceptionType;
 import com.dayaeyak.user.common.exception.type.UserExceptionType;
 import com.dayaeyak.user.domain.user.QUser;
 import com.querydsl.core.types.dsl.StringPath;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 
@@ -22,6 +22,10 @@ public enum SearchType {
     private final StringPath path;
 
     public static SearchType of(String type) {
+        if (StringUtils.hasText(type)) {
+            throw new CustomRuntimeException(UserExceptionType.INVALID_SEARCH_TYPE);
+        }
+
         return Arrays.stream(SearchType.values())
                 .filter(searchType -> searchType.type.equalsIgnoreCase(type))
                 .findFirst()

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
@@ -6,7 +6,6 @@ import com.dayaeyak.user.domain.user.QUser;
 import com.querydsl.core.types.dsl.StringPath;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 
@@ -22,10 +21,6 @@ public enum SearchType {
     private final StringPath path;
 
     public static SearchType of(String type) {
-        if (StringUtils.hasText(type)) {
-            throw new CustomRuntimeException(UserExceptionType.INVALID_SEARCH_TYPE);
-        }
-
         return Arrays.stream(SearchType.values())
                 .filter(searchType -> searchType.type.equalsIgnoreCase(type))
                 .findFirst()

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
@@ -1,0 +1,18 @@
+package com.dayaeyak.user.domain.user.enums;
+
+import com.dayaeyak.user.domain.user.QUser;
+import com.querydsl.core.types.dsl.StringPath;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchType {
+
+    EMAIL("email", QUser.user.email),
+    NICKNAME("nickname", QUser.user.nickname),
+    ;
+
+    private final String type;
+    private final StringPath path;
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/SearchType.java
@@ -1,9 +1,14 @@
 package com.dayaeyak.user.domain.user.enums;
 
+import com.dayaeyak.user.common.exception.CustomRuntimeException;
+import com.dayaeyak.user.common.exception.type.CommonExceptionType;
+import com.dayaeyak.user.common.exception.type.UserExceptionType;
 import com.dayaeyak.user.domain.user.QUser;
 import com.querydsl.core.types.dsl.StringPath;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -15,4 +20,11 @@ public enum SearchType {
 
     private final String type;
     private final StringPath path;
+
+    public static SearchType of(String type) {
+        return Arrays.stream(SearchType.values())
+                .filter(searchType -> searchType.type.equalsIgnoreCase(type))
+                .findFirst()
+                .orElseThrow(() -> new CustomRuntimeException(UserExceptionType.INVALID_SEARCH_TYPE));
+    }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/SocialLoginFlag.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/SocialLoginFlag.java
@@ -1,0 +1,8 @@
+package com.dayaeyak.user.domain.user.enums;
+
+public enum SocialLoginFlag {
+
+    SUCCESS,
+    JOIN_REQUIRED,
+    ;
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/UserRole.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/UserRole.java
@@ -1,29 +1,23 @@
 package com.dayaeyak.user.domain.user.enums;
 
 import com.dayaeyak.user.common.exception.CustomRuntimeException;
-import com.dayaeyak.user.common.exception.type.UserExceptionType;
+import com.dayaeyak.user.common.exception.type.CommonExceptionType;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.stream.Stream;
 
-@Getter
-@RequiredArgsConstructor
 public enum UserRole {
 
-    MASTER("MASTER"),
-    SELLER("SELLER"),
-    NORMAL("NORMAL"),
+    MASTER,
+    SELLER,
+    NORMAL,
     ;
-
-    private final String role;
 
     @JsonCreator
     public static UserRole of(String role) {
         return Stream.of(UserRole.values())
-                .filter(userRole -> userRole.role.equalsIgnoreCase(role))
+                .filter(userRole -> userRole.name().equalsIgnoreCase(role))
                 .findFirst()
-                .orElseThrow(() -> new CustomRuntimeException(UserExceptionType.INVALID_USER_ROLE));
+                .orElseThrow(() -> new CustomRuntimeException(CommonExceptionType.INVALID_USER_ROLE));
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/enums/UserRole.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/enums/UserRole.java
@@ -1,5 +1,8 @@
 package com.dayaeyak.user.domain.user.enums;
 
+import com.dayaeyak.user.common.exception.CustomRuntimeException;
+import com.dayaeyak.user.common.exception.type.UserExceptionType;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,10 +19,11 @@ public enum UserRole {
 
     private final String role;
 
+    @JsonCreator
     public static UserRole of(String role) {
         return Stream.of(UserRole.values())
                 .filter(userRole -> userRole.role.equalsIgnoreCase(role))
                 .findFirst()
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(() -> new CustomRuntimeException(UserExceptionType.INVALID_USER_ROLE));
     }
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/jpa/UserSocialJpaRepository.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/jpa/UserSocialJpaRepository.java
@@ -1,0 +1,11 @@
+package com.dayaeyak.user.domain.user.jpa;
+
+import com.dayaeyak.user.domain.user.User;
+import com.dayaeyak.user.domain.user.UserSocial;
+import com.dayaeyak.user.domain.user.enums.ProviderType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSocialJpaRepository extends JpaRepository<UserSocial, Long> {
+
+    boolean existsByUserAndProviderTypeAndProviderId(User user, ProviderType providerType, String providerId);
+}

--- a/src/main/java/com/dayaeyak/user/domain/user/querydsl/UserQuerydslRepository.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/querydsl/UserQuerydslRepository.java
@@ -1,5 +1,6 @@
 package com.dayaeyak.user.domain.user.querydsl;
 
+import com.dayaeyak.user.domain.user.enums.SearchType;
 import com.dayaeyak.user.domain.user.enums.UserRole;
 import com.dayaeyak.user.domain.user.querydsl.dto.response.UserSearchProjectionDto;
 import org.springframework.data.domain.Page;
@@ -10,8 +11,8 @@ public interface UserQuerydslRepository {
     Page<UserSearchProjectionDto> searchPage(
             Pageable pageable,
             Long userId,
-            String email,
-            String nickname,
-            UserRole role
+            UserRole role,
+            String keyword,
+            SearchType searchType
     );
 }

--- a/src/main/java/com/dayaeyak/user/domain/user/querydsl/UserQuerydslRepositoryImpl.java
+++ b/src/main/java/com/dayaeyak/user/domain/user/querydsl/UserQuerydslRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dayaeyak.user.domain.user.querydsl;
 
+import com.dayaeyak.user.domain.user.enums.SearchType;
 import com.dayaeyak.user.domain.user.enums.UserRole;
 import com.dayaeyak.user.domain.user.querydsl.dto.response.QUserSearchProjectionDto;
 import com.dayaeyak.user.domain.user.querydsl.dto.response.UserSearchProjectionDto;
@@ -30,14 +31,13 @@ public class UserQuerydslRepositoryImpl implements UserQuerydslRepository {
     public Page<UserSearchProjectionDto> searchPage(
             Pageable pageable,
             Long userId,
-            String email,
-            String nickname,
-            UserRole role
+            UserRole role,
+            String keyword,
+            SearchType searchType
     ) {
         Predicate[] whereClauses = {
                 eqUserId(userId),
-                eqEmail(email),
-                eqNickname(nickname),
+                eqSearchType(keyword, searchType),
                 eqRole(role)
         };
 
@@ -61,6 +61,10 @@ public class UserQuerydslRepositoryImpl implements UserQuerydslRepository {
                 .where(whereClauses);
 
         return PageableExecutionUtils.getPage(data, pageable, count::fetchOne);
+    }
+
+    private BooleanExpression eqSearchType(String keyword, SearchType searchType) {
+        return searchType != null ? searchType.getPath().contains(keyword) : null;
     }
 
     private BooleanExpression eqUserId(Long userId) {


### PR DESCRIPTION
## 📝 요약(Summary)

- API 정리
- 소셜 로그인 처리 로직 추가

## 💫 구현 및 변경 사항 (Details)

소셜 로그인 처리 로직 추가
- 이미 계정이 존재하는 경우
 - 요청한 소셜 서비스 타입에 해당하는 데이터가 있으면 로그인 처리
 - 요청한 소셜 서비스 타입에 해당하는 데이터가 없으면 데이터 생성 후 로그인 처리
- 계정이 존재하지 않는 경우
 - 요청한 소셜 서비스 타입으로 회원가입을 진행하도록 처리

User-Service API
- 로그인 유저 마이페이지 조회 GET /users/my
- 로그인 유저 마이페이지 수정 PATCH /users/my
- 관리자 유저 검색 GET /admin/users
- 관리자 특정 유저 수정PATCH /admin/users/{userId}
- Auth-Service 회원 가입 API 내부 통신 유저 생성 POST /internal/users/create-user
- Auth-Service 로그인 API 내부 통신 유저 조회 GET /internal/users/find-user
- Auth-Service 토큰 재발급 API 내부 통신 유저 조회 GET /internal/users/{userId}

리팩토링
- ArgumentResolver를 통해 인증 유저 정보를 Passport 객체에 주입하여 사용하도록 리팩토링 (@PassportHolder Passport passport)
- 관리자(MASTER 권한)용 API 엔드포인트 분리

## 📸스크린샷 (선택)

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [x] Reviewers에 팀원 등록

## 💬 TODO ( 미완성일 경우 )

## 기타/주의사항